### PR TITLE
#146 fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,5 @@ forgeVersion=28.1.40
 mappingType=snapshot
 mappingVersion=20190725-1.14.3
 modVersion=0.13.
-modVersionValue=3
+modVersionValue=4
 jeiVersion=6.0.0.13

--- a/src/main/java/tamaized/aov/common/capabilities/CapabilityList.java
+++ b/src/main/java/tamaized/aov/common/capabilities/CapabilityList.java
@@ -195,7 +195,6 @@ public class CapabilityList {
 					handlePlayerCopy(event.getEntityPlayer(), event.getOriginal(), AOV);
 					handlePlayerCopy(event.getEntityPlayer(), event.getOriginal(), POLYMORPH);
 				}
-				FIELD_capabilityProvider_valid.invoke(event.getOriginal(), false);
 			} catch (Throwable e) {
 				e.printStackTrace();
 			}


### PR DESCRIPTION
Deleted line, that invalidates all player capabilities on PlayerClone.
As mentioned in #146, this line is useless since Forge update.

We tested this change on server with friends for a couple days, works fine, including Vampire support.

Also, if PR will be accepted, please, merge it onto 1.15.x branch.